### PR TITLE
Change output-dir argument to --out flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/coreos/prometheus-operator v0.36.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/spf13/cobra v0.0.5
+	github.com/spf13/viper v1.3.2
 )

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -41,10 +41,9 @@ func NewGenerateCommand() *cobra.Command {
 }
 
 func runGenerateCommand() error {
-	outputDir := filepath.Clean(viper.GetString("out"))
-	outputFile := "alerts.md"
-	if outExt := filepath.Ext(outputDir); len(outExt) > 0 {
-		outputDir, outputFile = filepath.Split(outputDir)
+	outputPath := filepath.Clean(viper.GetString("out"))
+	if filepath.Ext(outputPath) == "" {
+		outputPath = filepath.Join(outputPath, "alerts.md")
 	}
 
 	workingDir, err := os.Getwd()
@@ -52,16 +51,11 @@ func runGenerateCommand() error {
 		return fmt.Errorf("get working dir: %w", err)
 	}
 
-	fileExtension := filepath.Ext(outputFile)
-	output, err := rendering.Render(workingDir, fileExtension)
+	output, err := rendering.Render(workingDir, filepath.Ext(outputPath))
 	if err != nil {
 		return fmt.Errorf("rendering: %w", err)
 	}
 
-	if outputDir == "" {
-		outputDir = workingDir
-	}
-	outputPath := filepath.Join(outputDir, outputFile)
 	err = ioutil.WriteFile(outputPath, []byte(output), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("write document: %w", err)

--- a/internal/commands/generate.go
+++ b/internal/commands/generate.go
@@ -5,9 +5,9 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 
 	"github.com/plexsystems/promdoc/internal/rendering"
 )
@@ -15,12 +15,18 @@ import (
 // NewGenerateCommand creates a new generate command
 func NewGenerateCommand() *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "generate <output-dir>",
+		Use:   "generate",
 		Short: "Generate documentation from a given folder",
-		Args:  cobra.ExactArgs(1),
+
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.BindPFlag("out", cmd.Flags().Lookup("out")); err != nil {
+				return fmt.Errorf("bind out flag: %w", err)
+			}
+			return nil
+		},
 
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := runGenerateCommand(args[0]); err != nil {
+			if err := runGenerateCommand(); err != nil {
 				return fmt.Errorf("generate: %w", err)
 			}
 
@@ -28,27 +34,33 @@ func NewGenerateCommand() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().StringP("out", "o", "alerts.md",
+		"file name or path for the output-file")
+
 	return &cmd
 }
 
-func runGenerateCommand(outputFile string) error {
+func runGenerateCommand() error {
+	out := viper.GetString("out")
+	outputDir, outputFile := path.Split(out)
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("get working dir: %w", err)
 	}
-
-	fileTokens := strings.Split(outputFile, ".")
-	if len(fileTokens) == 0 {
-		return fmt.Errorf("get file extension: %w", err)
+	if outputDir == "" {
+		outputDir = workingDir
+	}
+	if outputFile == "" {
+		outputFile = "alerts.md"
 	}
 
-	fileExtension := fileTokens[len(fileTokens)-1]
+	fileExtension := path.Ext(outputFile)
 	output, err := rendering.Render(workingDir, fileExtension)
 	if err != nil {
 		return fmt.Errorf("rendering: %w", err)
 	}
 
-	outputPath := path.Join(workingDir, outputFile)
+	outputPath := path.Join(outputDir, outputFile)
 	err = ioutil.WriteFile(outputPath, []byte(output), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("write document: %w", err)


### PR DESCRIPTION
--out receives a file-path or file-name
If not set by the user the flag has a default value of alerts.md
If the flag is set to a directory path the ouput will be a file named alerts.md in that path
paths to a directory should finish with "/"
If the file is set to a file-name with no path, current working dir will be used

This pr addresses issue #7