### PR TITLE
Alert description

### DIFF
--- a/examples/csv/expected.csv
+++ b/examples/csv/expected.csv
@@ -1,2 +1,2 @@
-Name,RuleGroup,Summary,Message,Severity,Runbook
-TestAlert,TestGroup,TestSummary,,TestSeverity,TestRunbookURL
+Name,RuleGroup,Summary,Description,Severity,Runbook
+TestAlert,TestGroup,TestSummary,TestDescription,TestSeverity,TestRunbookURL

--- a/examples/markdown/expected.md
+++ b/examples/markdown/expected.md
@@ -6,6 +6,6 @@
 
 ## TestGroup
 
-|Name|Summary|Severity|Runbook|
-|---|---|---|---|
-|TestAlert|TestSummary|TestSeverity|[TestRunbookURL](TestRunbookURL)|
+|Name|Summary|Description|Severity|Runbook|
+|---|---|---|---|---|
+|TestAlert|TestSummary|TestDescription|TestSeverity|[TestRunbookURL](TestRunbookURL)|

--- a/examples/rule2.yaml
+++ b/examples/rule2.yaml
@@ -9,7 +9,7 @@ spec:
     - alert: TestAlert
       annotations:
         summary: TestSummary
-        description: TestDescription
+        message: TestDescription
         runbook_url: TestRunbookURL
       labels:
         severity: TestSeverity

--- a/internal/rendering/csv.go
+++ b/internal/rendering/csv.go
@@ -18,9 +18,9 @@ func RenderCSV(ruleGroups []promv1.RuleGroup) string {
 			summary := rule.Annotations["summary"]
 			var description string
 			if val, ok := rule.Annotations["description"]; ok {
-				description = trimSpaceNewlineInString(val)
+				description = replacePromQLInString(trimSpaceNewlineInString(val))
 			} else if val, ok := rule.Annotations["message"]; ok {
-				description = trimSpaceNewlineInString(val)
+				description = replacePromQLInString(trimSpaceNewlineInString(val))
 			}
 			severity := rule.Labels["severity"]
 			runbookURL := rule.Annotations["runbook_url"]

--- a/internal/rendering/csv.go
+++ b/internal/rendering/csv.go
@@ -15,13 +15,13 @@ func RenderCSV(ruleGroups []promv1.RuleGroup) string {
 				continue
 			}
 
-			var summary string
-			if val, ok := rule.Annotations["summary"]; ok {
-				summary = val
+			summary := rule.Annotations["summary"]
+			var description string
+			if val, ok := rule.Annotations["description"]; ok {
+				description = trimSpaceNewlineInString(val)
 			} else if val, ok := rule.Annotations["message"]; ok {
-				summary = replacePromQLInString(trimSpaceNewlineInString(val))
+				description = trimSpaceNewlineInString(val)
 			}
-			description := trimSpaceNewlineInString(rule.Annotations["description"])
 			severity := rule.Labels["severity"]
 			runbookURL := rule.Annotations["runbook_url"]
 

--- a/internal/rendering/csv.go
+++ b/internal/rendering/csv.go
@@ -8,19 +8,24 @@ import (
 
 // RenderCSV renders CSV
 func RenderCSV(ruleGroups []promv1.RuleGroup) string {
-	document := "Name,RuleGroup,Summary,Message,Severity,Runbook\n"
+	document := "Name,RuleGroup,Summary,Description,Severity,Runbook\n"
 	for _, ruleGroup := range ruleGroups {
 		for _, rule := range ruleGroup.Rules {
 			if rule.Alert == "" {
 				continue
 			}
 
-			summary := rule.Annotations["summary"]
-			message := trimSpaceNewlineInString(rule.Annotations["message"])
+			var summary string
+			if val, ok := rule.Annotations["summary"]; ok {
+				summary = val
+			} else if val, ok := rule.Annotations["message"]; ok {
+				summary = replacePromQLInString(trimSpaceNewlineInString(val))
+			}
+			description := trimSpaceNewlineInString(rule.Annotations["description"])
 			severity := rule.Labels["severity"]
 			runbookURL := rule.Annotations["runbook_url"]
 
-			document += fmt.Sprintf("%s,%s,%s,%s,%s,%s\n", rule.Alert, ruleGroup.Name, summary, message, severity, runbookURL)
+			document += fmt.Sprintf("%s,%s,%s,%s,%s,%s\n", rule.Alert, ruleGroup.Name, summary, description, severity, runbookURL)
 		}
 	}
 

--- a/internal/rendering/csv_test.go
+++ b/internal/rendering/csv_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-func TestCSV(t *testing.T) {
+func testCSV(t *testing.T, filename string) {
 	expected, err := ioutil.ReadFile("../../examples/csv/expected.csv")
 	if err != nil {
 		t.Fatal("read expected file")
 	}
 
-	actual, err := Render("../../examples/rule.yaml", ".csv")
+	actual, err := Render(filename, ".csv")
 	if err != nil {
 		t.Fatal("getting rule groups:", err)
 	}
@@ -19,4 +19,11 @@ func TestCSV(t *testing.T) {
 	if string(expected) != actual {
 		t.Error("rendered markdown did not match expected output")
 	}
+}
+func TestCSVWithDescription(t *testing.T) {
+	testCSV(t, "../../examples/rule.yaml")
+}
+
+func TestCSVWithMessage(t *testing.T) {
+	testCSV(t, "../../examples/rule2.yaml")
 }

--- a/internal/rendering/markdown.go
+++ b/internal/rendering/markdown.go
@@ -49,9 +49,9 @@ func RenderMarkdown(ruleGroups []promv1.RuleGroup) string {
 			summary := rule.Annotations["summary"]
 			var description string
 			if val, ok := rule.Annotations["description"]; ok {
-				description = trimSpaceNewlineInString(val)
+				description = replacePromQLInString(trimSpaceNewlineInString(val))
 			} else if val, ok := rule.Annotations["message"]; ok {
-				description = trimSpaceNewlineInString(val)
+				description = replacePromQLInString(trimSpaceNewlineInString(val))
 			}
 			severity := rule.Labels["severity"]
 			runbookURL := rule.Annotations["runbook_url"]

--- a/internal/rendering/markdown.go
+++ b/internal/rendering/markdown.go
@@ -46,15 +46,13 @@ func RenderMarkdown(ruleGroups []promv1.RuleGroup) string {
 				continue
 			}
 
-			var summary string
-			if val, ok := rule.Annotations["summary"]; ok {
-				summary = val
-			} else if val, ok := rule.Annotations["description"]; ok {
-				summary = val
+			summary := rule.Annotations["summary"]
+			var description string
+			if val, ok := rule.Annotations["description"]; ok {
+				description = trimSpaceNewlineInString(val)
 			} else if val, ok := rule.Annotations["message"]; ok {
-				summary = replacePromQLInString(trimSpaceNewlineInString(val))
+				description = trimSpaceNewlineInString(val)
 			}
-			description := trimSpaceNewlineInString(rule.Annotations["description"])
 			severity := rule.Labels["severity"]
 			runbookURL := rule.Annotations["runbook_url"]
 			if runbookURL != "" {

--- a/internal/rendering/markdown.go
+++ b/internal/rendering/markdown.go
@@ -34,10 +34,10 @@ func RenderMarkdown(ruleGroups []promv1.RuleGroup) string {
 			document += "## " + ruleGroup.Name
 			document += "\n\n"
 
-			document += "|Name|Summary|Severity|Runbook|"
+			document += "|Name|Summary|Description|Severity|Runbook|"
 			document += "\n"
 
-			document += "|---|---|---|---|"
+			document += "|---|---|---|---|---|"
 			document += "\n"
 		}
 
@@ -46,15 +46,22 @@ func RenderMarkdown(ruleGroups []promv1.RuleGroup) string {
 				continue
 			}
 
-			summary := rule.Annotations["summary"]
+			var summary string
+			if val, ok := rule.Annotations["summary"]; ok {
+				summary = val
+			} else if val, ok := rule.Annotations["description"]; ok {
+				summary = val
+			} else if val, ok := rule.Annotations["message"]; ok {
+				summary = replacePromQLInString(trimSpaceNewlineInString(val))
+			}
+			description := trimSpaceNewlineInString(rule.Annotations["description"])
 			severity := rule.Labels["severity"]
-
 			runbookURL := rule.Annotations["runbook_url"]
 			if runbookURL != "" {
 				runbookURL = fmt.Sprintf("[%s](%s)", runbookURL, runbookURL)
 			}
 
-			document += fmt.Sprintf("|%s|%s|%s|%s|", rule.Alert, summary, severity, runbookURL)
+			document += fmt.Sprintf("|%s|%s|%s|%s|%s", rule.Alert, summary, description, severity, runbookURL)
 			document += "\n"
 		}
 	}

--- a/internal/rendering/markdown.go
+++ b/internal/rendering/markdown.go
@@ -61,7 +61,7 @@ func RenderMarkdown(ruleGroups []promv1.RuleGroup) string {
 				runbookURL = fmt.Sprintf("[%s](%s)", runbookURL, runbookURL)
 			}
 
-			document += fmt.Sprintf("|%s|%s|%s|%s|%s", rule.Alert, summary, description, severity, runbookURL)
+			document += fmt.Sprintf("|%s|%s|%s|%s|%s|", rule.Alert, summary, description, severity, runbookURL)
 			document += "\n"
 		}
 	}

--- a/internal/rendering/markdown_test.go
+++ b/internal/rendering/markdown_test.go
@@ -5,13 +5,13 @@ import (
 	"testing"
 )
 
-func TestMarkdown(t *testing.T) {
+func testMarkdown(t *testing.T, filename string) {
 	expected, err := ioutil.ReadFile("../../examples/markdown/expected.md")
 	if err != nil {
 		t.Fatal("read expected file")
 	}
 
-	actual, err := Render("../../examples/rule.yaml", ".md")
+	actual, err := Render(filename, ".md")
 	if err != nil {
 		t.Fatal("getting rule groups:", err)
 	}
@@ -19,4 +19,12 @@ func TestMarkdown(t *testing.T) {
 	if string(expected) != actual {
 		t.Error("rendered markdown did not match expected output")
 	}
+}
+
+func TestMarkdownWithDescription(t *testing.T) {
+	testCSV(t, "../../examples/rule.yaml")
+}
+
+func TestMarkdownWithMessage(t *testing.T) {
+	testCSV(t, "../../examples/rule2.yaml")
 }

--- a/internal/rendering/markdown_test.go
+++ b/internal/rendering/markdown_test.go
@@ -22,9 +22,9 @@ func testMarkdown(t *testing.T, filename string) {
 }
 
 func TestMarkdownWithDescription(t *testing.T) {
-	testCSV(t, "../../examples/rule.yaml")
+	testMarkdown(t, "../../examples/rule.yaml")
 }
 
 func TestMarkdownWithMessage(t *testing.T) {
-	testCSV(t, "../../examples/rule2.yaml")
+	testMarkdown(t, "../../examples/rule2.yaml")
 }

--- a/internal/rendering/rendering.go
+++ b/internal/rendering/rendering.go
@@ -114,3 +114,8 @@ func trimSpaceNewlineInString(s string) string {
 	re := regexp.MustCompile(`\r?\n|\| `)
 	return re.ReplaceAllString(s, " ")
 }
+
+func replacePromQLInString(s string) string {
+	re := regexp.MustCompile(` \| `)
+	return re.ReplaceAllString(s, " \\| ")
+}


### PR DESCRIPTION
Some monitoring-mixins have annotations : description, summary, message, ...

Generated markdown : 

# Alerts

## Rule Groups

* [AlertmanagerAlerts](#AlertmanagerAlerts)
* [BlackboxAlerts](#BlackboxAlerts)
* [ElasticsearchAlerts](#ElasticsearchAlerts)
* [HAProxyAlerts](#HAProxyAlerts)
* [MemcachedAlerts](#MemcachedAlerts)
* [MysqlAlerts](#MysqlAlerts)
* [PostgreSQLAlerts](#PostgreSQLAlerts)
* [RabbitMQAlerts](#RabbitMQAlerts)
* [RedisAlerts](#RedisAlerts)
* [SolrAlerts](#SolrAlerts)
* [VarnishAlerts](#VarnishAlerts)
* [cert-manager](#cert-manager)
* [deadmansswitch](#deadmansswitch)
* [etcd](#etcd)
* [kube-apiserver-slos](#kube-apiserver-slos)
* [kube-prometheus-node-alerting](#kube-prometheus-node-alerting)
* [kubernetes-absent](#kubernetes-absent)
* [kubernetes-apps](#kubernetes-apps)
* [kubernetes-resources](#kubernetes-resources)
* [kubernetes-storage](#kubernetes-storage)
* [kubernetes-system](#kubernetes-system)
* [kubernetes-system-apiserver](#kubernetes-system-apiserver)
* [kubernetes-system-controller-manager](#kubernetes-system-controller-manager)
* [kubernetes-system-kubelet](#kubernetes-system-kubelet)
* [kubernetes-system-scheduler](#kubernetes-system-scheduler)
* [logging_elasticsearch.alerts](#logging_elasticsearch.alerts)
* [loki_alerts](#loki_alerts)
* [node-disk](#node-disk)
* [node-exporter](#node-exporter)
* [node-network](#node-network)
* [node_exporter](#node_exporter)
* [prometheus](#prometheus)
* [promtail_alerts](#promtail_alerts)
* [sk5_node](#sk5_node)
* [thanos-bucket-replicate.rules](#thanos-bucket-replicate.rules)
* [thanos-compact.rules](#thanos-compact.rules)
* [thanos-component-absent.rules](#thanos-component-absent.rules)
* [thanos-query.rules](#thanos-query.rules)
* [thanos-receive.rules](#thanos-receive.rules)
* [thanos-rule.rules](#thanos-rule.rules)
* [thanos-sidecar.rules](#thanos-sidecar.rules)
* [thanos-store.rules](#thanos-store.rules)

## AlertmanagerAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|AlertmanagerConfigurationReload|AlertManager configuration reload (instance {{ $labels.instance }})|AlertManager configuration reload error   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|AlertmanagerNotificationsFailing||Alertmanager is seeing errors for integration {{$labels.integration}}|critical||

## BlackboxAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|StatusCode|Status Code (instance {{ $labels.instance }})|HTTP status code is not 200-299   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|SslCertificateWillExpireSoon|SSL certificate will expire soon (instance {{ $labels.instance }})|SSL certificate expires in 30 days   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|SslCertificateHasExpired|SSL certificate has expired (instance {{ $labels.instance }})|SSL certificate has expired already   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## ElasticsearchAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ElasticHeapUsageTooHigh|Elastic Heap Usage Too High (instance {{ $labels.instance }})|The heap usage is over 90% for 5m   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|ElasticHeapUsageWarning|Elastic Heap Usage warning (instance {{ $labels.instance }})|The heap usage is over 80% for 5m   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|ElasticClusterRed|Elastic Cluster Red (instance {{ $labels.instance }})|Elastic Cluster Red status   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NumberOfElasticHealthyNodes|Number of Elastic Healthy Nodes (instance {{ $labels.instance }})|Number Healthy Nodes less then number_of_nodes   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NumberOfElasticHealthyDataNodes|Number of Elastic Healthy Data Nodes (instance {{ $labels.instance }})|Number Healthy Data Nodes less then number_of_data_nodes   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NumberOfRelocationShards|Number of relocation shards (instance {{ $labels.instance }})|Number of relocation shards for 20 min   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NumberOfInitializingShards|Number of initializing shards (instance {{ $labels.instance }})|Number of initializing shards for 10 min   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NumberOfUnassignedShards|Number of unassigned shards (instance {{ $labels.instance }})|Number of unassigned shards for 2 min   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NumberOfPendingTasks|Number of pending tasks (instance {{ $labels.instance }})|Number of pending tasks for 10 min. Cluster works slowly.   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|ElasticNoNewDocuments|Elastic no new documents (instance {{ $labels.instance }})|No new documents for 10 min!   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## HAProxyAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|HaproxyDown|HAProxy down (instance {{ $labels.instance }})|HAProxy down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyHighHttp4xxErrorRateBackend|HAProxy high HTTP 4xx error rate backend (instance {{ $labels.instance }})|Too many HTTP requests with status 4xx (> 5%) on backend {{ $labels.fqdn }}/{{ $labels.backend }}   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyHighHttp4xxErrorRateBackend|HAProxy high HTTP 4xx error rate backend (instance {{ $labels.instance }})|Too many HTTP requests with status 5xx (> 5%) on backend {{ $labels.fqdn }}/{{ $labels.backend }}   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyHighHttp4xxErrorRateServer|HAProxy high HTTP 4xx error rate server (instance {{ $labels.instance }})|Too many HTTP requests with status 4xx (> 5%) on server {{ $labels.server }}   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyHighHttp5xxErrorRateServer|HAProxy high HTTP 5xx error rate server (instance {{ $labels.instance }})|Too many HTTP requests with status 5xx (> 5%) on server {{ $labels.server }}   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyBackendConnectionErrors|HAProxy backend connection errors (instance {{ $labels.instance }})|Too many connection errors to {{ $labels.fqdn }}/{{ $labels.backend }} backend (> 5%). Request throughput may be to high.   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyServerResponseErrors|HAProxy server response errors (instance {{ $labels.instance }})|Too many response errors to {{ $labels.server }} server (> 5%).   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyServerConnectionErrors|HAProxy server connection errors (instance {{ $labels.instance }})|Too many connection errors to {{ $labels.server }} server (> 5%). Request throughput may be to high.   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyBackendMaxActiveSession|HAProxy backend max active session (instance {{ $labels.instance }})|HAproxy backend {{ $labels.fqdn }}/{{ $labels.backend }} is reaching session limit (> 80%).   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|HaproxyPendingRequests|HAProxy pending requests (instance {{ $labels.instance }})|Some HAProxy requests are pending on {{ $labels.fqdn }}/{{ $labels.backend }} backend   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|HaproxyHttpSlowingDown|HAProxy HTTP slowing down (instance {{ $labels.instance }})|Average request time is increasing   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|HaproxyRetryHigh|HAProxy retry high (instance {{ $labels.instance }})|High rate of retry on {{ $labels.fqdn }}/{{ $labels.backend }} backend   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|HaproxyBackendDown|HAProxy backend down (instance {{ $labels.instance }})|HAProxy backend is down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyServerDown|HAProxy server down (instance {{ $labels.instance }})|HAProxy server is down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HaproxyFrontendSecurityBlockedRequests|HAProxy frontend security blocked requests (instance {{ $labels.instance }})|HAProxy is blocking requests for security reason   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|HaproxyServerHealthcheckFailure|HAProxy server healthcheck failure (instance {{ $labels.instance }})|Some server healthcheck are failing on {{ $labels.server }}   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## MemcachedAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|MemcachedDown|Memcached down (instance {{ $labels.instance }})|Memcached node down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|NotEnoughConnections|Not enough connections (instance {{ $labels.instance }})|Memcached instance should have more connections (> 5)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|Respawns|Memcached uptime is low. (instance {{ $labels.instance }})|Memcached instance uptime should have higher   VALUE = {{ $value }}   LABELS: {{ $labels }}|medium||
|TooManyYieldedConnections|Too many yielded connections (instance {{ $labels.instance }})|Memcached instance has too many yielded connections   VALUE = {{ $value }}   LABELS: {{ $labels }}|medium||

## MysqlAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|MysqlDown|MySQL down (instance {{ $labels.instance }})|MySQL instance is down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|OpenFilesHigh|Instance {{ $labels.instance }} open files high|Open files is high. Please consider increasing open_files_limit.|warning||
|ReadBufferSizeTooBig|Instance {{ $labels.instance }} Read buffer size is bigger than max. allowed packet size|Read buffer size (read_buffer_size) is bigger than max. allowed packet size (max_allowed_packet).This can break your replication.|warning||
|SortBufferMissconfigured|Instance {{ $labels.instance }} Sort buffer possibly missconfigured|Sort buffer size is either too big or too small. A good value for sort_buffer_size is between 256k and 4M.|warning||
|ThreadStackSizeTooSmall|Instance {{ $labels.instance }} Thread stack size is too small|Thread stack size is too small. This can cause problems when you use Stored Language constructs for example. A typical is 256k for thread_stack_size.|warning||
|MaxConnectionsLimited|Instance {{ $labels.instance }} Used more than 80% of max connections limited|Used more than 80% of max connections limited|warning||
|InnoDBForceRecovery|Instance {{ $labels.instance }} InnoDB Force Recovery is enabled|InnoDB Force Recovery is enabled. This mode should be used for data recovery purposes only. It prohibits writing to the data.|warning||
|InnoDBLogFileSizeTooSmall|Instance {{ $labels.instance }} InnoDB Log File size is too small|The InnoDB Log File size is possibly too small. Choosing a small InnoDB Log File size can have significant performance impacts.|warning||
|InnoDBFlushLogTransactionCommit|Instance {{ $labels.instance }} InnoDB Flush Log at Transaction Commit|InnoDB Flush Log at Transaction Commit is set to a values != 1. This can lead to a loss of commited transactions in case of a power failure.|warning||
|TableDefinitionCacheTooSmall|Instance {{ $labels.instance }} Table definition cache too small|Your Table Definition Cache is possibly too small. If it is much too small this can have significant performance impacts!|page||
|TableOpenCacheTooSmall|Instance {{ $labels.instance }} Table open cache too small|Your Table Open Cache is possibly too small (old name Table Cache). If it is much too small this can have significant performance impacts!|page||
|ThreadStackSizeTooSmall|Instance {{ $labels.instance }} Thread stack size is possibly too small|Thread stack size is possibly too small. This can cause problems when you use Stored Language constructs for example. A typical is 256k for thread_stack_size.|page||
|InnoDBBufferPoolInstancesTooSmall|Instance {{ $labels.instance }} InnoDB Buffer Pool Instances is too small|If you are using MySQL 5.5 and higher you should use several InnoDB Buffer Pool Instances for performance reasons. Some rules are: InnoDB Buffer Pool Instance should be at least 1 Gbyte in size. InnoDB Buffer Pool Instances you can set equal to the number of cores of your machine.|page||
|InnoDBPlugin|Instance {{ $labels.instance }} InnoDB Plugin is enabled|InnoDB Plugin is enabled|page||
|BinaryLogDisabled|Instance {{ $labels.instance }} Binary Log is disabled|Binary Log is disabled. This prohibits you to do Point in Time Recovery (PiTR).|warning||
|BinlogCacheSizeTooSmall|Instance {{ $labels.instance }} Binlog Cache size too small|Binlog Cache size is possibly to small. A value of 1 Mbyte or higher is OK.|page||
|BinlogStatementCacheSizeTooSmall|Instance {{ $labels.instance }} Binlog Statement Cache size too small|Binlog Statement Cache size is possibly to small. A value of 1 Mbyte or higher is typically OK.|page||
|BinlogTransactionCacheSizeTooSmall|Instance {{ $labels.instance }} Binlog Transaction Cache size too small|Binlog Transaction Cache size is possibly to small. A value of 1 Mbyte or higher is typically OK.|page||
|SyncBinlog|Instance {{ $labels.instance }} Sync Binlog is enabled|Sync Binlog is enabled. This leads to higher data security but on the cost of write performance.|page||
|IOThreadStopped|Instance {{ $labels.instance }} IO thread stopped|IO thread has stopped. This is usually because it cannot connect to the Master any more.|critical||
|SQLThreadStopped|Instance {{ $labels.instance }} SQL thread stopped|SQL thread has stopped. This is usually because it cannot apply a SQL statement received from the master.|critical||
|SQLThreadStopped|Instance {{ $labels.instance }} Sync Binlog is enabled|SQL thread has stopped. This is usually because it cannot apply a SQL statement received from the master.|critical||
|SlaveLaggingBehindMaster|Instance {{ $labels.instance }} Slave lagging behind Master|Slave is lagging behind Master. Please check if Slave threads are running and if there are some performance issues!|warning||
|SlaveNotReady|Instance {{ $labels.instance }} Slave is NOT read only|Slave is NOT set to read only. You can accidentally manipulate data on the slave and get inconsistencies...|page||

## PostgreSQLAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|PostgresqlDown|PostgreSQL down (instance {{ $labels.instance }})|PostgreSQL instance is down   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|ReplicationLag|Replication lag (instance {{ $labels.instance }})|PostgreSQL replication lag is going up (> 10s)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|TableNotVaccumed|Table not vaccumed (instance {{ $labels.instance }})|Table has not been vaccum for 24 hours   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|TableNotAnalyzed|Table not analyzed (instance {{ $labels.instance }})|Table has not been analyzed for 24 hours   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|TooManyConnections|Too many connections (instance {{ $labels.instance }})|PostgreSQL instance has too many connections   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NotEnoughConnections|Not enough connections (instance {{ $labels.instance }})|PostgreSQL instance should have more connections (> 5)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|DeadLocks|Dead locks (instance {{ $labels.instance }})|PostgreSQL has dead-locks   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## RabbitMQAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|RabbitmqDown|Rabbitmq down (instance {{ $labels.instance }})|RabbitMQ node down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|ClusterPartition|Cluster partition (instance {{ $labels.instance }})|Cluster partition   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|TooManyConnections|Too many connections (instance {{ $labels.instance }})|RabbitMQ instance has too many connections (> 1000)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|OutOfMemory|Out of memory (instance {{ $labels.instance }})|Memory available for RabbmitMQ is low (< 10%)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|DeadLetterQueueFillingUp|Dead letter queue filling up (instance {{ $labels.instance }})|Dead letter queue is filling up (> 10 msgs)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|TooManyMessagesInQueue|Too many messages in queue (instance {{ $labels.instance }})|Queue is filling up (> 1000 msgs)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|SlowQueueConsuming|Slow queue consuming (instance {{ $labels.instance }})|Queue messages are consumed slowly (> 60s)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## RedisAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|RedisDown|Redis down (instance {{ $labels.instance }})|Redis instance is down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|OutOfMemory|Out of memory (instance {{ $labels.instance }})|Redis is running out of memory (> 90%)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|ReplicationBroken|Replication broken (instance {{ $labels.instance }})|Redis instance lost a slave   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|TooManyConnections|Too many connections (instance {{ $labels.instance }})|Redis instance has too many connections   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|NotEnoughConnections|Not enough connections (instance {{ $labels.instance }})|Redis instance should have more connectionsn  VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|RejectedConnections|Rejected connections (instance {{ $labels.instance }})|Some connections to Redis has been rejected   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## SolrAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|SolrDown|Solr down (instance {{ $labels.instance }})|Solr node down   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||

## VarnishAlerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|VarnishDown|Varnish {{ $labels.instance }} is currently down||critical||

## cert-manager

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|certmanager_absent||Cert Manager has dissapeared from Prometheus service discovery|critical||
|certmanager_cert_expiry_soon||The cert `{{ $labels.name }}` is {{ $value  humanizeDuration }} from expiry, it should have renewed over a week ago|critical||
|certmanager_cert_not_ready||The cert `{{ $labels.name }}` is not ready to serve traffic.|critical||
|certmanager_cert_expiry_metric_missing||The metric used to observe cert-manager cert expiry is missing|critical||
|certmanager_hitting_rate_limits||Cert manager hitting LetsEncrypt rate limits|critical||

## deadmansswitch

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|DeadMansSwitch|Alerting DeadMansSwitch|This is a DeadMansSwitch meant to ensure that the entire Alerting pipeline is functional.|critical||

## etcd

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|etcdMembersDown||etcd cluster "{{ $labels.job }}": members are down ({{ $value }}).|critical||
|etcdInsufficientMembers||etcd cluster "{{ $labels.job }}": insufficient members ({{ $value }}).|critical||
|etcdNoLeader||etcd cluster "{{ $labels.job }}": member {{ $labels.instance }} has no leader.|critical||
|etcdHighNumberOfLeaderChanges||etcd cluster "{{ $labels.job }}": {{ $value }} leader changes within the last 15 minutes. Frequent elections may be a sign of insufficient resources, high network latency, or disruptions by other components and should be investigated.|warning||
|etcdHighNumberOfFailedGRPCRequests||etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.|warning||
|etcdHighNumberOfFailedGRPCRequests||etcd cluster "{{ $labels.job }}": {{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}.|critical||
|etcdGRPCRequestsSlow||etcd cluster "{{ $labels.job }}": gRPC requests to {{ $labels.grpc_method }} are taking {{ $value }}s on etcd instance {{ $labels.instance }}.|critical||
|etcdMemberCommunicationSlow||etcd cluster "{{ $labels.job }}": member communication with {{ $labels.To }} is taking {{ $value }}s on etcd instance {{ $labels.instance }}.|warning||
|etcdHighNumberOfFailedProposals||etcd cluster "{{ $labels.job }}": {{ $value }} proposal failures within the last 30 minutes on etcd instance {{ $labels.instance }}.|warning||
|etcdHighFsyncDurations||etcd cluster "{{ $labels.job }}": 99th percentile fync durations are {{ $value }}s on etcd instance {{ $labels.instance }}.|warning||
|etcdHighCommitDurations||etcd cluster "{{ $labels.job }}": 99th percentile commit durations {{ $value }}s on etcd instance {{ $labels.instance }}.|warning||
|etcdHighNumberOfFailedHTTPRequests||{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}|warning||
|etcdHighNumberOfFailedHTTPRequests||{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}.|critical||
|etcdHTTPRequestsSlow||etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow.|warning||

## kube-apiserver-slos

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubeAPIErrorBudgetBurn|The API server is burning too much error budget.|The API server is burning too much error budget.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn)|
|KubeAPIErrorBudgetBurn|The API server is burning too much error budget.|The API server is burning too much error budget.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn)|
|KubeAPIErrorBudgetBurn|The API server is burning too much error budget.|The API server is burning too much error budget.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn)|
|KubeAPIErrorBudgetBurn|The API server is burning too much error budget.|The API server is burning too much error budget.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapierrorbudgetburn)|

## kube-prometheus-node-alerting

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|NodeDiskRunningFull||Device {{ $labels.device }} of node-exporter {{ $labels.namespace }}/{{ $labels.pod }} will be full within the next 24 hours.|warning||
|NodeDiskRunningFull||Device {{ $labels.device }} of node-exporter {{ $labels.namespace }}/{{ $labels.pod }} will be full within the next 2 hours.|critical||

## kubernetes-absent

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|AlertmanagerDown||Alertmanager has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerdown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-alertmanagerdown)|
|KubeStateMetricsDown||KubeStateMetrics has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatemetricsdown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatemetricsdown)|
|NodeExporterDown||NodeExporter has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodeexporterdown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-nodeexporterdown)|
|PrometheusDown||Prometheus has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusdown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusdown)|
|PrometheusOperatorDown||PrometheusOperator has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatordown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-prometheusoperatordown)|

## kubernetes-apps

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubePodCrashLooping|Pod is crash looping.|Pod {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }}) is restarting {{ printf "%.2f" $value }} times / 5 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodcrashlooping)|
|KubePodNotReady|Pod has been in a non-ready state for more than 15 minutes.|Pod {{ $labels.namespace }}/{{ $labels.pod }} has been in a non-ready state for longer than 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepodnotready)|
|KubeDeploymentGenerationMismatch|Deployment generation mismatch due to possible roll-back|Deployment generation for {{ $labels.namespace }}/{{ $labels.deployment }} does not match, this indicates that the Deployment has failed but has not been rolled back.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentgenerationmismatch)|
|KubeDeploymentReplicasMismatch|Deployment has not matched the expected number of replicas.|Deployment {{ $labels.namespace }}/{{ $labels.deployment }} has not matched the expected number of replicas for longer than 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedeploymentreplicasmismatch)|
|KubeStatefulSetReplicasMismatch|Deployment has not matched the expected number of replicas.|StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} has not matched the expected number of replicas for longer than 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetreplicasmismatch)|
|KubeStatefulSetGenerationMismatch|StatefulSet generation mismatch due to possible roll-back|StatefulSet generation for {{ $labels.namespace }}/{{ $labels.statefulset }} does not match, this indicates that the StatefulSet has failed but has not been rolled back.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetgenerationmismatch)|
|KubeStatefulSetUpdateNotRolledOut|StatefulSet update has not been rolled out.|StatefulSet {{ $labels.namespace }}/{{ $labels.statefulset }} update has not been rolled out.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubestatefulsetupdatenotrolledout)|
|KubeDaemonSetRolloutStuck|DaemonSet rollout is stuck.|DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} has not finished or progressed for at least 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetrolloutstuck)|
|KubeContainerWaiting|Pod container waiting longer than 1 hour|Pod {{ $labels.namespace }}/{{ $labels.pod }} container {{ $labels.container}} has been in waiting state for longer than 1 hour.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontainerwaiting)|
|KubeDaemonSetNotScheduled|DaemonSet pods are not scheduled.|{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are not scheduled.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetnotscheduled)|
|KubeDaemonSetMisScheduled|DaemonSet pods are misscheduled.|{{ $value }} Pods of DaemonSet {{ $labels.namespace }}/{{ $labels.daemonset }} are running where they are not supposed to run.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubedaemonsetmisscheduled)|
|KubeJobCompletion|Job did not complete in time|Job {{ $labels.namespace }}/{{ $labels.job_name }} is taking more than 12 hours to complete.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobcompletion)|
|KubeJobFailed|Job failed to complete.|Job {{ $labels.namespace }}/{{ $labels.job_name }} failed to complete.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubejobfailed)|
|KubeHpaReplicasMismatch|HPA has not matched descired number of replicas.|HPA {{ $labels.namespace }}/{{ $labels.hpa }} has not matched the desired number of replicas for longer than 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpareplicasmismatch)|
|KubeHpaMaxedOut|HPA is running at max replicas|HPA {{ $labels.namespace }}/{{ $labels.hpa }} has been running at max replicas for longer than 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubehpamaxedout)|

## kubernetes-resources

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubeCPUOvercommit|Cluster has overcommitted CPU resource requests.|Cluster has overcommitted CPU resource requests for Pods and cannot tolerate node failure.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuovercommit)|
|KubeMemoryOvercommit|Cluster has overcommitted memory resource requests.|Cluster has overcommitted memory resource requests for Pods and cannot tolerate node failure.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryovercommit)|
|KubeCPUQuotaOvercommit|Cluster has overcommitted CPU resource requests.|Cluster has overcommitted CPU resource requests for Namespaces.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecpuquotaovercommit)|
|KubeMemoryQuotaOvercommit|Cluster has overcommitted memory resource requests.|Cluster has overcommitted memory resource requests for Namespaces.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubememoryquotaovercommit)|
|KubeQuotaFullyUsed|Namespace quota is fully used.|Namespace {{ $labels.namespace }} is using {{ $value  humanizePercentage }} of its {{ $labels.resource }} quota.|info|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubequotafullyused)|
|CPUThrottlingHigh|Processes experience elevated CPU throttling.|{{ $value  humanizePercentage }} throttling of CPU in namespace {{ $labels.namespace }} for container {{ $labels.container }} in pod {{ $labels.pod }}.|info|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-cputhrottlinghigh)|

## kubernetes-storage

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubePersistentVolumeFillingUp|PersistentVolume is filling up.|The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value  humanizePercentage }} free.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup)|
|KubePersistentVolumeFillingUp|PersistentVolume is filling up.|Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value  humanizePercentage }} is available.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumefillingup)|
|KubePersistentVolumeErrors|PersistentVolume is having issues with provisioning.|The persistent volume {{ $labels.persistentvolume }} has status {{ $labels.phase }}.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubepersistentvolumeerrors)|

## kubernetes-system

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubeVersionMismatch|Different semantic versions of Kubernetes components running.|There are {{ $value }} different semantic versions of Kubernetes components running.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeversionmismatch)|
|KubeClientErrors|Kubernetes API server client is experiencing errors.|Kubernetes API server client '{{ $labels.job }}/{{ $labels.instance }}' is experiencing {{ $value  humanizePercentage }} errors.'|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclienterrors)|

## kubernetes-system-apiserver

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubeClientCertificateExpiration|Client certificate is about to expire.|A client certificate used to authenticate to the apiserver is expiring in less than 7.0 days.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration)|
|KubeClientCertificateExpiration|Client certificate is about to expire.|A client certificate used to authenticate to the apiserver is expiring in less than 24.0 hours.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeclientcertificateexpiration)|
|AggregatedAPIErrors|An aggregated API has reported errors.|An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has reported errors. The number of errors have increased for it in the past five minutes. High values indicate that the availability of the service changes too often.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-aggregatedapierrors](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-aggregatedapierrors)|
|AggregatedAPIDown|An aggregated API is down.|An aggregated API {{ $labels.name }}/{{ $labels.namespace }} has been only {{ $value  humanize }}% available over the last 10m.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-aggregatedapidown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-aggregatedapidown)|
|KubeAPIDown|Target disappeared from Prometheus target discovery.|KubeAPI has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapidown)|

## kubernetes-system-controller-manager

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubeControllerManagerDown|Target disappeared from Prometheus target discovery.|KubeControllerManager has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubecontrollermanagerdown)|

## kubernetes-system-kubelet

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubeNodeNotReady|Node is not ready.|{{ $labels.node }} has been unready for more than 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodenotready)|
|KubeNodeUnreachable|Node is unreachable.|{{ $labels.node }} is unreachable and some workloads may be rescheduled.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeunreachable](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodeunreachable)|
|KubeletTooManyPods|Kubelet is running at capacity.|Kubelet '{{ $labels.node }}' is running at {{ $value  humanizePercentage }} of its Pod capacity.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubelettoomanypods)|
|KubeNodeReadinessFlapping|Node readiness status is flapping.|The readiness status of node {{ $labels.node }} has changed {{ $value }} times in the last 15 minutes.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubenodereadinessflapping)|
|KubeletPlegDurationHigh|Kubelet Pod Lifecycle Event Generator is taking too long to relist.|The Kubelet Pod Lifecycle Event Generator has a 99th percentile duration of {{ $value }} seconds on node {{ $labels.node }}.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletplegdurationhigh)|
|KubeletPodStartUpLatencyHigh|Kubelet Pod startup latency is too high.|Kubelet Pod startup 99th percentile latency is {{ $value }} seconds on node {{ $labels.node }}.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletpodstartuplatencyhigh](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletpodstartuplatencyhigh)|
|KubeletClientCertificateExpiration|Kubelet client certificate is about to expire.|Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value  humanizeDuration }}.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration)|
|KubeletClientCertificateExpiration|Kubelet client certificate is about to expire.|Client certificate for Kubelet on node {{ $labels.node }} expires in {{ $value  humanizeDuration }}.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificateexpiration)|
|KubeletServerCertificateExpiration|Kubelet server certificate is about to expire.|Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value  humanizeDuration }}.|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration)|
|KubeletServerCertificateExpiration|Kubelet server certificate is about to expire.|Server certificate for Kubelet on node {{ $labels.node }} expires in {{ $value  humanizeDuration }}.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificateexpiration)|
|KubeletClientCertificateRenewalErrors|Kubelet has failed to renew its client certificate.|Kubelet on node {{ $labels.node }} has failed to renew its client certificate ({{ $value  humanize }} errors in the last 5 minutes).|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificaterenewalerrors](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletclientcertificaterenewalerrors)|
|KubeletServerCertificateRenewalErrors|Kubelet has failed to renew its server certificate.|Kubelet on node {{ $labels.node }} has failed to renew its server certificate ({{ $value  humanize }} errors in the last 5 minutes).|warning|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificaterenewalerrors](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletservercertificaterenewalerrors)|
|KubeletDown|Target disappeared from Prometheus target discovery.|Kubelet has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeletdown)|

## kubernetes-system-scheduler

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|KubeSchedulerDown|Target disappeared from Prometheus target discovery.|KubeScheduler has disappeared from Prometheus target discovery.|critical|[https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown](https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeschedulerdown)|

## logging_elasticsearch.alerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ElasticsearchClusterNotHealthy|Cluster health status is RED|Cluster {{ $labels.cluster }} health status has been RED for at least 2m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet.|critical||
|ElasticsearchClusterNotHealthy|Cluster health status is YELLOW|Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated.|warning||
|ElasticsearchBulkRequestsRejectionJumps|High Bulk Rejection Ratio - {{ $value }}%|High Bulk Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed.|warning||
|ElasticsearchNodeDiskWatermarkReached|Disk Low Watermark Reached - disk saturation is {{ $value }}%|Disk Low Watermark Reached at {{ $labels.node }} node in {{ $labels.cluster }} cluster. Shards can not be allocated to this node anymore. You should consider adding more disk to the node.|alert||
|ElasticsearchNodeDiskWatermarkReached|Disk High Watermark Reached - disk saturation is {{ $value }}%|Disk High Watermark Reached at {{ $labels.node }} node in {{ $labels.cluster }} cluster. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node.|high||
|ElasticsearchJVMHeapUseHigh|JVM Heap usage on the node is high|JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%.|alert||
|AggregatedLoggingSystemCPUHigh|System CPU usage is high|System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%|alert||
|ElasticsearchProcessCPUHigh|ES process CPU usage is high|ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%|alert||

## loki_alerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|LokiRequestErrors||{{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors. |critical||
|LokiRequestLatency||{{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency. |critical||

## node-disk

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|OutOfDiskSpace|Out of disk space (instance {{ $labels.instance }})|Disk is almost full (< 10% left)   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|OutOfInodes|Out of inodes (instance {{ $labels.instance }})|Disk is almost running out of available inodes (< 10% left)   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|UnusualDiskWriteLatency|Unusual disk write latency (instance {{ $labels.instance }})|Disk latency is growing (write operations > 100ms)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|UnusualDiskReadLatency|Unusual disk read latency (instance {{ $labels.instance }})|Disk latency is growing (read operations > 100ms)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## node-exporter

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|NodeFilesystemSpaceFillingUp|Filesystem is predicted to run out of space within the next 24 hours.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left and is filling up.|warning||
|NodeFilesystemSpaceFillingUp|Filesystem is predicted to run out of space within the next 4 hours.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left and is filling up fast.|critical||
|NodeFilesystemAlmostOutOfSpace|Filesystem has less than 5% space left.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.|warning||
|NodeFilesystemAlmostOutOfSpace|Filesystem has less than 3% space left.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available space left.|critical||
|NodeFilesystemFilesFillingUp|Filesystem is predicted to run out of inodes within the next 24 hours.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up.|warning||
|NodeFilesystemFilesFillingUp|Filesystem is predicted to run out of inodes within the next 4 hours.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left and is filling up fast.|critical||
|NodeFilesystemAlmostOutOfFiles|Filesystem has less than 5% inodes left.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.|warning||
|NodeFilesystemAlmostOutOfFiles|Filesystem has less than 3% inodes left.|Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left.|critical||
|NodeNetworkReceiveErrs|Network interface is reporting many receive errors.|{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} receive errors in the last two minutes.|warning||
|NodeNetworkTransmitErrs|Network interface is reporting many transmit errors.|{{ $labels.instance }} interface {{ $labels.device }} has encountered {{ printf "%.0f" $value }} transmit errors in the last two minutes.|warning||
|NodeHighNumberConntrackEntriesUsed|Number of conntrack are getting close to the limit.|{{ $value  humanizePercentage }} of conntrack entries are used.|warning||
|NodeTextFileCollectorScrapeError|Node Exporter text file collector failed to scrape.|Node Exporter text file collector failed to scrape.|warning||
|NodeClockSkewDetected|Clock skew detected.|Clock on {{ $labels.instance }} is out of sync by more than 300s. Ensure NTP is configured correctly on this host.|warning||
|NodeClockNotSynchronising|Clock not synchronising.|Clock on {{ $labels.instance }} is not synchronising. Ensure NTP is configured on this host.|warning||

## node-network

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|NetworkReceiveErrors||Network interface "{{ $labels.device }}" showing receive errors on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"|warning||
|NetworkTransmitErrors||Network interface "{{ $labels.device }}" showing transmit errors on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"|warning||
|NodeNetworkInterfaceFlapping||Network interface "{{ $labels.device }}" changing it's up status often on node-exporter {{ $labels.namespace }}/{{ $labels.pod }}"|warning||

## node_exporter

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|OutOfMemory|Out of memory (instance {{ $labels.instance }})|Node memory is filling up (< 10% left)   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|HighCpuLoad|High CPU load (instance {{ $labels.instance }})|CPU load is > 80%   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|SystemdServiceFailed|SystemD service failed (instance {{ $labels.instance }})|Service {{ $labels.name }} failed   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|UnusualNetworkThroughputIn|Unusual network throughput in (instance {{ $labels.instance }})|Host network interfaces are probably receiving too much data (> 100 MB/s)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|UnusualNetworkThroughputOut|Unusual network throughput out (instance {{ $labels.instance }})|Host network interfaces are probably sending too much data (> 100 MB/s)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|UnusualDiskReadRate|Unusual disk read rate (instance {{ $labels.instance }})|Disk is probably reading too much data (> 50 MB/s)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|UnusualDiskWriteRate|Unusual disk write rate (instance {{ $labels.instance }})|Disk is probably writing too much data (> 50 MB/s)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|OutOfDiskSpace|Out of disk space (instance {{ $labels.instance }})|Disk is almost full (< 10% left)   VALUE = {{ $value }}   LABELS: {{ $labels }}|critical||
|UnusualDiskReadLatency|Unusual disk read latency (instance {{ $labels.instance }})|Disk latency is growing (read operations > 100ms)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||
|UnusualDiskWriteLatency|Unusual disk write latency (instance {{ $labels.instance }})|Disk latency is growing (write operations > 100ms)   VALUE = {{ $value }}   LABELS: {{ $labels }}|warning||

## prometheus

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|PrometheusBadConfig|Failed Prometheus configuration reload.|Prometheus {{$labels.instance}} has failed to reload its configuration.|critical||
|PrometheusNotificationQueueRunningFull|Prometheus alert notification queue predicted to run full in less than 30m.|Alert notification queue of Prometheus {{$labels.instance}} is running full.|warning||
|PrometheusErrorSendingAlertsToSomeAlertmanagers|Prometheus has encountered more than 1% errors sending alerts to a specific Alertmanager.|{{ printf "%.1f" $value }}% errors while sending alerts from Prometheus {{$labels.instance}} to Alertmanager {{$labels.alertmanager}}.|warning||
|PrometheusErrorSendingAlertsToAnyAlertmanager|Prometheus encounters more than 3% errors sending alerts to any Alertmanager.|{{ printf "%.1f" $value }}% minimum errors while sending alerts from Prometheus {{$labels.instance}} to any Alertmanager.|critical||
|PrometheusNotConnectedToAlertmanagers|Prometheus is not connected to any Alertmanagers.|Prometheus {{$labels.instance}} is not connected to any Alertmanagers.|warning||
|PrometheusTSDBReloadsFailing|Prometheus has issues reloading blocks from disk.|Prometheus {{$labels.instance}} has detected {{$value  humanize}} reload failures over the last 3h.|warning||
|PrometheusTSDBCompactionsFailing|Prometheus has issues compacting blocks.|Prometheus {{$labels.instance}} has detected {{$value  humanize}} compaction failures over the last 3h.|warning||
|PrometheusNotIngestingSamples|Prometheus is not ingesting samples.|Prometheus {{$labels.instance}} is not ingesting samples.|warning||
|PrometheusDuplicateTimestamps|Prometheus is dropping samples with duplicate timestamps.|Prometheus {{$labels.instance}} is dropping {{ printf "%.4g" $value  }} samples/s with different values but duplicated timestamp.|warning||
|PrometheusOutOfOrderTimestamps|Prometheus drops samples with out-of-order timestamps.|Prometheus {{$labels.instance}} is dropping {{ printf "%.4g" $value  }} samples/s with timestamps arriving out of order.|warning||
|PrometheusRemoteStorageFailures|Prometheus fails to send samples to remote storage.|Prometheus {{$labels.instance}} failed to send {{ printf "%.1f" $value }}% of the samples to {{ $labels.remote_name}}:{{ $labels.url }}|critical||
|PrometheusRemoteWriteBehind|Prometheus remote write is behind.|Prometheus {{$labels.instance}} remote write is {{ printf "%.1f" $value }}s behind for {{ $labels.remote_name}}:{{ $labels.url }}.|critical||
|PrometheusRemoteWriteDesiredShards|Prometheus remote write desired shards calculation wants to run more than configured max shards.|Prometheus {{$labels.instance}} remote write desired shards calculation wants to run {{ $value }} shards for queue {{ $labels.remote_name}}:{{ $labels.url }}, which is more than the max of {{ printf `prometheus_remote_storage_shards_max{instance="%s",job="prometheus"}` $labels.instance  query  first  value }}.|warning||
|PrometheusRuleFailures|Prometheus is failing rule evaluations.|Prometheus {{$labels.instance}} has failed to evaluate {{ printf "%.0f" $value }} rules in the last 5m.|critical||
|PrometheusMissingRuleEvaluations|Prometheus is missing rule evaluations due to slow rule group evaluation.|Prometheus {{$labels.instance}} has missed {{ printf "%.0f" $value }} rule group evaluations in the last 5m.|warning||

## promtail_alerts

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|PromtailRequestsErrors||{{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}% errors. |critical||
|PromtailRequestLatency||{{ $labels.job }} {{ $labels.route }} is experiencing {{ printf "%.2f" $value }}s 99th percentile latency. |critical||
|PromtailFileLagging||{{ $labels.instance }} {{ $labels.job }} {{ $labels.path }} has been lagging by more than 100kb for more than 15m. |critical||
|PromtailFileMissing||{{ $labels.instance }} {{ $labels.job }} {{ $labels.path }} matches the glob but is not being tailed. |critical||

## sk5_node

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|NodeRebooted||The node has been rebooted.|warning||

## thanos-bucket-replicate.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosBucketReplicateIsDown|Thanos Replicate has disappeared from Prometheus target discovery.|Thanos Replicate has disappeared from Prometheus target discovery.|warning||
|ThanosBucketReplicateErrorRate|Thanose Replicate is failing to run.|Thanos Replicate failing to run, {{ $value  humanize }}% of attempts failed.|warning||
|ThanosBucketReplicateRunLatency|Thanos Replicate has a high latency for replicate operations.|Thanos Replicate {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for the replicate operations.|warning||

## thanos-compact.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosCompactMultipleRunning|Thanos Compact has multiple instances running.|No more than one Thanos Compact instance should be running at once. There are {{ $value }}|warning||
|ThanosCompactHalted|Thanos Compact has failed to run ans is now halted.|Thanos Compact {{$labels.job}} has failed to run and now is halted.|warning||
|ThanosCompactHighCompactionFailures|Thanos Compact is failing to execute compactions.|Thanos Compact {{$labels.job}} is failing to execute {{ $value  humanize }}% of compactions.|warning||
|ThanosCompactBucketHighOperationFailures|Thanos Compact Bucket is having a high number of operation failures.|Thanos Compact {{$labels.job}} Bucket is failing to execute {{ $value  humanize }}% of operations.|warning||
|ThanosCompactHasNotRun|Thanos Compact has not uploaded anything for last 24 hours.|Thanos Compact {{$labels.job}} has not uploaded anything for 24 hours.|warning||

## thanos-component-absent.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosCompactIsDown|thanos component has disappeared from Prometheus target discovery.|ThanosCompact has disappeared from Prometheus target discovery.|warning||
|ThanosQueryIsDown|thanos component has disappeared from Prometheus target discovery.|ThanosQuery has disappeared from Prometheus target discovery.|warning||
|ThanosReceiveIsDown|thanos component has disappeared from Prometheus target discovery.|ThanosReceive has disappeared from Prometheus target discovery.|warning||
|ThanosRuleIsDown|thanos component has disappeared from Prometheus target discovery.|ThanosRule has disappeared from Prometheus target discovery.|warning||
|ThanosSidecarIsDown|thanos component has disappeared from Prometheus target discovery.|ThanosSidecar has disappeared from Prometheus target discovery.|warning||
|ThanosStoreIsDown|thanos component has disappeared from Prometheus target discovery.|ThanosStore has disappeared from Prometheus target discovery.|warning||

## thanos-query.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosQueryHttpRequestQueryErrorRateHigh|Thanos Query is failing to handle requests.|Thanos Query {{$labels.job}} is failing to handle {{ $value  humanize }}% of "query" requests.|warning||
|ThanosQueryHttpRequestQueryRangeErrorRateHigh|Thanos Query is failing to handle requests.|Thanos Query {{$labels.job}} is failing to handle {{ $value  humanize }}% of "query_range" requests.|warning||
|ThanosQueryGrpcServerErrorRate|Thanos Query is failing to handle requests.|Thanos Query {{$labels.job}} is failing to handle {{ $value  humanize }}% of requests.|warning||
|ThanosQueryGrpcClientErrorRate|Thanos Query is failing to send requests.|Thanos Query {{$labels.job}} is failing to send {{ $value  humanize }}% of requests.|warning||
|ThanosQueryHighDNSFailures|Thanos Query is having high number of DNS failures.|Thanos Query {{$labels.job}} have {{ $value  humanize }}% of failing DNS queries for store endpoints.|warning||
|ThanosQueryInstantLatencyHigh|Thanos Query has high latency for queries.|Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for instant queries.|warning||
|ThanosQueryRangeLatencyHigh|Thanos Query has high latency for queries.|Thanos Query {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for range queries.|warning||

## thanos-receive.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosReceiveHttpRequestErrorRateHigh|Thanos Receive is failing to handle requests.|Thanos Receive {{$labels.job}} is failing to handle {{ $value  humanize }}% of requests.|warning||
|ThanosReceiveHttpRequestLatencyHigh|Thanos Receive has high HTTP requests latency.|Thanos Receive {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for requests.|warning||
|ThanosReceiveHighReplicationFailures|Thanos Receive is having high number of replication failures.|Thanos Receive {{$labels.job}} is failing to replicate {{ $value  humanize }}% of requests.|warning||
|ThanosReceiveHighForwardRequestFailures|Thanos Receive is failing to forward requests.|Thanos Receive {{$labels.job}} is failing to forward {{ $value  humanize }}% of requests.|warning||
|ThanosReceiveHighHashringFileRefreshFailures|Thanos Receive is failing to refresh hasring file.|Thanos Receive {{$labels.job}} is failing to refresh hashring file, {{ $value  humanize }} of attempts failed.|warning||
|ThanosReceiveConfigReloadFailure|Thanos Receive has not been able to reload configuration.|Thanos Receive {{$labels.job}} has not been able to reload hashring configurations.|warning||
|ThanosReceiveNoUpload|Thanos Receive has not uploaded latest data to object storage.|Thanos Receive {{ $labels.instance }} of {{$labels.job}} has not uploaded latest data to object storage.|warning||

## thanos-rule.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosRuleQueueIsDroppingAlerts|Thanos Rule is failing to queue alerts.|Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to queue alerts.|warning||
|ThanosRuleSenderIsFailingAlerts|Thanos Rule is failing to send alerts to alertmanager.|Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to send alerts to alertmanager.|warning||
|ThanosRuleHighRuleEvaluationFailures|Thanos Rule is failing to evaluate rules.|Thanos Rule {{$labels.job}} {{$labels.pod}} is failing to evaluate rules.|warning||
|ThanosRuleHighRuleEvaluationWarnings|Thanos Rule has high number of evaluation warnings.|Thanos Rule {{$labels.job}} {{$labels.pod}} has high number of evaluation warnings.|info||
|ThanosRuleRuleEvaluationLatencyHigh|Thanos Rule has high rule evaluation latency.|Thanos Rule {{$labels.job}}/{{$labels.pod}} has higher evaluation latency than interval for {{$labels.rule_group}}.|warning||
|ThanosRuleGrpcErrorRate|Thanos Rule is failing to handle grpc requests.|Thanos Rule {{$labels.job}} is failing to handle {{ $value  humanize }}% of requests.|warning||
|ThanosRuleConfigReloadFailure|Thanos Rule has not been able to reload configuration.|Thanos Rule {{$labels.job}} has not been able to reload its configuration.|info||
|ThanosRuleQueryHighDNSFailures|Thanos Rule is having high number of DNS failures.|Thanos Rule {{$labels.job}} has {{ $value  humanize }}% of failing DNS queries for query endpoints.|warning||
|ThanosRuleAlertmanagerHighDNSFailures|Thanos Rule is having high number of DNS failures.|Thanos Rule {{$labels.job}} has {{ $value  humanize }}% of failing DNS queries for Alertmanager endpoints.|warning||
|ThanosRuleNoEvaluationFor10Intervals|Thanos Rule has rule groups that did not evaluate for 10 intervals.|Thanos Rule {{$labels.job}} has {{ $value  humanize }}% rule groups that did not evaluate for at least 10x of their expected interval.|info||
|ThanosNoRuleEvaluations|Thanos Rule did not perform any rule evaluations.|Thanos Rule {{$labels.job}} did not perform any rule evaluations in the past 2 minutes.|warning||

## thanos-sidecar.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosSidecarPrometheusDown|Thanos Sidecar cannot connect to Prometheus|Thanos Sidecar {{$labels.job}} {{$labels.pod}} cannot connect to Prometheus.|warning||
|ThanosSidecarUnhealthy|Thanos Sidecar is unhealthy.|Thanos Sidecar {{$labels.job}} {{$labels.pod}} is unhealthy for {{ $value }} seconds.|warning||

## thanos-store.rules

|Name|Summary|Description|Severity|Runbook|
|---|---|---|---|---|
|ThanosStoreGrpcErrorRate|Thanos Store is failing to handle qrpcd requests.|Thanos Store {{$labels.job}} is failing to handle {{ $value  humanize }}% of requests.|warning||
|ThanosStoreSeriesGateLatencyHigh|Thanos Store has high latency for store series gate requests.|Thanos Store {{$labels.job}} has a 99th percentile latency of {{ $value }} seconds for store series gate requests.|warning||
|ThanosStoreBucketHighOperationFailures|Thanos Store Bucket is failing to execute operations.|Thanos Store {{$labels.job}} Bucket is failing to execute {{ $value  humanize }}% of operations.|warning||
|ThanosStoreObjstoreOperationLatencyHigh|Thanos Store is having high latency for bucket operations.|Thanos Store {{$labels.job}} Bucket has a 99th percentile latency of {{ $value }} seconds for the bucket operations.|warning||
