### PR TITLE
Extract Expr and For fields from prometheus alert rule

### DIFF
--- a/examples/csv/expected.csv
+++ b/examples/csv/expected.csv
@@ -1,5 +1,5 @@
-Name,RuleGroup,Summary,Description,Severity,Runbook
-DescriptionAlert,Description,TestSummary,TestDescription,TestSeverity,TestRunbookURL
-MessageAlert,Message,TestSummary,TestMessage,TestSeverity,TestRunbookURL
-Alert1,MultiAlert1,TestSummary1,TestAlert1,TestSeverity1,TestRunbookURL1
-Alert2,MultiAlert2,TestSummary2,TestAlert2,TestSeverity2,TestRunbookURL2
+Name,RuleGroup,Summary,Description,Severity,Expr,For,Runbook
+DescriptionAlert,Description,TestSummary,TestDescription,TestSeverity,up == 0,1w,TestRunbookURL
+MessageAlert,Message,TestSummary,TestMessage,TestSeverity,api_http_request_latencies_second{quantile="0.5"} > 1,15m,TestRunbookURL
+Alert1,MultiAlert1,TestSummary1,TestAlert1,TestSeverity1,job:request_latency_seconds:mean5m{job="myjob"} > 0.5,2d,TestRunbookURL1
+Alert2,MultiAlert2,TestSummary2,TestAlert2,TestSeverity2,(   predict_linear(prometheus_notifications_queue_length{job="prometheus"}[5m], 60 * 30) >   min_over_time(prometheus_notifications_queue_capacity{job="prometheus"}[5m]) ),,TestRunbookURL2

--- a/examples/markdown/expected.md
+++ b/examples/markdown/expected.md
@@ -9,24 +9,24 @@
 
 ## Description
 
-|Name|Summary|Description|Severity|Runbook|
-|---|---|---|---|---|
-|DescriptionAlert|TestSummary|TestDescription|TestSeverity|[TestRunbookURL](TestRunbookURL)|
+|Name|Summary|Description|Severity|Expr|For|Runbook|
+|---|---|---|---|---|---|---|
+|DescriptionAlert|TestSummary|TestDescription|TestSeverity|up == 0|1w|[TestRunbookURL](TestRunbookURL)|
 
 ## Message
 
-|Name|Summary|Description|Severity|Runbook|
-|---|---|---|---|---|
-|MessageAlert|TestSummary|TestMessage|TestSeverity|[TestRunbookURL](TestRunbookURL)|
+|Name|Summary|Description|Severity|Expr|For|Runbook|
+|---|---|---|---|---|---|---|
+|MessageAlert|TestSummary|TestMessage|TestSeverity|api_http_request_latencies_second{quantile="0.5"} > 1|15m|[TestRunbookURL](TestRunbookURL)|
 
 ## MultiAlert1
 
-|Name|Summary|Description|Severity|Runbook|
-|---|---|---|---|---|
-|Alert1|TestSummary1|TestAlert1|TestSeverity1|[TestRunbookURL1](TestRunbookURL1)|
+|Name|Summary|Description|Severity|Expr|For|Runbook|
+|---|---|---|---|---|---|---|
+|Alert1|TestSummary1|TestAlert1|TestSeverity1|job:request_latency_seconds:mean5m{job="myjob"} > 0.5|2d|[TestRunbookURL1](TestRunbookURL1)|
 
 ## MultiAlert2
 
-|Name|Summary|Description|Severity|Runbook|
-|---|---|---|---|---|
-|Alert2|TestSummary2|TestAlert2|TestSeverity2|[TestRunbookURL2](TestRunbookURL2)|
+|Name|Summary|Description|Severity|Expr|For|Runbook|
+|---|---|---|---|---|---|---|
+|Alert2|TestSummary2|TestAlert2|TestSeverity2|(   predict_linear(prometheus_notifications_queue_length{job="prometheus"}[5m], 60 * 30) >   min_over_time(prometheus_notifications_queue_capacity{job="prometheus"}[5m]) )||[TestRunbookURL2](TestRunbookURL2)|

--- a/examples/markdown/expected.md
+++ b/examples/markdown/expected.md
@@ -11,22 +11,22 @@
 
 |Name|Summary|Description|Severity|Expr|For|Runbook|
 |---|---|---|---|---|---|---|
-|DescriptionAlert|TestSummary|TestDescription|TestSeverity|up == 0|1w|[TestRunbookURL](TestRunbookURL)|
+|DescriptionAlert|TestSummary|TestDescription|TestSeverity|`up == 0`|1w|[TestRunbookURL](TestRunbookURL)|
 
 ## Message
 
 |Name|Summary|Description|Severity|Expr|For|Runbook|
 |---|---|---|---|---|---|---|
-|MessageAlert|TestSummary|TestMessage|TestSeverity|api_http_request_latencies_second{quantile="0.5"} > 1|15m|[TestRunbookURL](TestRunbookURL)|
+|MessageAlert|TestSummary|TestMessage|TestSeverity|`api_http_request_latencies_second{quantile="0.5"} > 1`|15m|[TestRunbookURL](TestRunbookURL)|
 
 ## MultiAlert1
 
 |Name|Summary|Description|Severity|Expr|For|Runbook|
 |---|---|---|---|---|---|---|
-|Alert1|TestSummary1|TestAlert1|TestSeverity1|job:request_latency_seconds:mean5m{job="myjob"} > 0.5|2d|[TestRunbookURL1](TestRunbookURL1)|
+|Alert1|TestSummary1|TestAlert1|TestSeverity1|`job:request_latency_seconds:mean5m{job="myjob"} > 0.5`|2d|[TestRunbookURL1](TestRunbookURL1)|
 
 ## MultiAlert2
 
 |Name|Summary|Description|Severity|Expr|For|Runbook|
 |---|---|---|---|---|---|---|
-|Alert2|TestSummary2|TestAlert2|TestSeverity2|(   predict_linear(prometheus_notifications_queue_length{job="prometheus"}[5m], 60 * 30) >   min_over_time(prometheus_notifications_queue_capacity{job="prometheus"}[5m]) )||[TestRunbookURL2](TestRunbookURL2)|
+|Alert2|TestSummary2|TestAlert2|TestSeverity2|`(   predict_linear(prometheus_notifications_queue_length{job="prometheus"}[5m], 60 * 30) >   min_over_time(prometheus_notifications_queue_capacity{job="prometheus"}[5m]) )`||[TestRunbookURL2](TestRunbookURL2)|

--- a/examples/ruleWithDescription.yaml
+++ b/examples/ruleWithDescription.yaml
@@ -4,12 +4,14 @@ metadata:
   name: test-description-rule
 spec:
   groups:
-  - name: Description
-    rules:
-    - alert: DescriptionAlert
-      annotations:
-        summary: TestSummary
-        description: TestDescription
-        runbook_url: TestRunbookURL
-      labels:
-        severity: TestSeverity
+    - name: Description
+      rules:
+        - alert: DescriptionAlert
+          expr: up == 0
+          for: 1w
+          annotations:
+            summary: TestSummary
+            description: TestDescription
+            runbook_url: TestRunbookURL
+          labels:
+            severity: TestSeverity

--- a/examples/ruleWithMessage.yaml
+++ b/examples/ruleWithMessage.yaml
@@ -4,12 +4,14 @@ metadata:
   name: test-message-rule
 spec:
   groups:
-  - name: Message
-    rules:
-    - alert: MessageAlert
-      annotations:
-        summary: TestSummary
-        message: TestMessage
-        runbook_url: TestRunbookURL
-      labels:
-        severity: TestSeverity
+    - name: Message
+      rules:
+        - alert: MessageAlert
+          expr: api_http_request_latencies_second{quantile="0.5"} > 1
+          for: 15m
+          annotations:
+            summary: TestSummary
+            message: TestMessage
+            runbook_url: TestRunbookURL
+          labels:
+            severity: TestSeverity

--- a/examples/ruleWithMultipleDocuments.yaml
+++ b/examples/ruleWithMultipleDocuments.yaml
@@ -8,6 +8,8 @@ spec:
     - name: MultiAlert1
       rules:
         - alert: Alert1
+          expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+          for: 2d
           annotations:
             summary: TestSummary1
             message: TestAlert1
@@ -24,6 +26,12 @@ spec:
     - name: MultiAlert2
       rules:
         - alert: Alert2
+          expr: |
+            (
+              predict_linear(prometheus_notifications_queue_length{job="prometheus"}[5m], 60 * 30)
+            >
+              min_over_time(prometheus_notifications_queue_capacity{job="prometheus"}[5m])
+            )
           annotations:
             summary: TestSummary2
             description: TestAlert2

--- a/generate/csv.go
+++ b/generate/csv.go
@@ -10,7 +10,7 @@ func CSV(path string, input string) (string, error) {
 		return "", fmt.Errorf("get rule groups: %w", err)
 	}
 
-	document := "Name,RuleGroup,Summary,Description,Severity,Runbook\n"
+	document := "Name,RuleGroup,Summary,Description,Severity,Expr,For,Runbook\n"
 	for _, ruleGroup := range ruleGroups {
 		for _, rule := range ruleGroup.Rules {
 			var description string
@@ -20,11 +20,12 @@ func CSV(path string, input string) (string, error) {
 				description = trimText(val)
 			}
 
+			expr := trimText(rule.Expr)
 			summary := rule.Annotations["summary"]
 			severity := rule.Labels["severity"]
 			runbookURL := rule.Annotations["runbook_url"]
 
-			document += fmt.Sprintf("%s,%s,%s,%s,%s,%s", rule.Alert, ruleGroup.Name, summary, description, severity, runbookURL)
+			document += fmt.Sprintf("%s,%s,%s,%s,%s,%s,%s,%s", rule.Alert, ruleGroup.Name, summary, description, severity, expr, rule.For, runbookURL)
 			document += "\n"
 		}
 	}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -86,6 +86,7 @@ func trimText(text string) string {
 
 	prom := regexp.MustCompile(` \| `)
 	text = prom.ReplaceAllString(text, " \\| ")
+	text = strings.TrimSpace(text)
 
 	return text
 }

--- a/generate/markdown.go
+++ b/generate/markdown.go
@@ -39,10 +39,10 @@ func Markdown(path string, input string) (string, error) {
 			document += "## " + ruleGroup.Name
 			document += "\n\n"
 
-			document += "|Name|Summary|Description|Severity|Runbook|"
+			document += "|Name|Summary|Description|Severity|Expr|For|Runbook|"
 			document += "\n"
 
-			document += "|---|---|---|---|---|"
+			document += "|---|---|---|---|---|---|---|"
 			document += "\n"
 		}
 
@@ -54,6 +54,7 @@ func Markdown(path string, input string) (string, error) {
 				description = trimText(val)
 			}
 
+			expr := trimText(rule.Expr)
 			summary := rule.Annotations["summary"]
 			severity := rule.Labels["severity"]
 			runbookURL := rule.Annotations["runbook_url"]
@@ -61,7 +62,7 @@ func Markdown(path string, input string) (string, error) {
 				runbookURL = fmt.Sprintf("[%s](%s)", runbookURL, runbookURL)
 			}
 
-			document += fmt.Sprintf("|%s|%s|%s|%s|%s|", rule.Alert, summary, description, severity, runbookURL)
+			document += fmt.Sprintf("|%s|%s|%s|%s|%s|%s|%s|", rule.Alert, summary, description, severity, expr, rule.For, runbookURL)
 			document += "\n"
 		}
 	}

--- a/generate/markdown.go
+++ b/generate/markdown.go
@@ -62,7 +62,7 @@ func Markdown(path string, input string) (string, error) {
 				runbookURL = fmt.Sprintf("[%s](%s)", runbookURL, runbookURL)
 			}
 
-			document += fmt.Sprintf("|%s|%s|%s|%s|%s|%s|%s|", rule.Alert, summary, description, severity, expr, rule.For, runbookURL)
+			document += fmt.Sprintf("|%s|%s|%s|%s|`%s`|%s|%s|", rule.Alert, summary, description, severity, expr, rule.For, runbookURL)
 			document += "\n"
 		}
 	}

--- a/generate/prometheus.go
+++ b/generate/prometheus.go
@@ -28,6 +28,8 @@ type ruleGroup struct {
 
 type rule struct {
 	Alert       string            `json:"alert"`
+	Expr        string            `json:"expr"`
+	For         string            `json:"for"`
 	Labels      map[string]string `json:"labels"`
 	Annotations map[string]string `json:"annotations"`
 }


### PR DESCRIPTION
Hey @jpreese, here's a PR to extract the `Expr` and `For` fields from the prometheus rules and export them in CSV & Markdown format.